### PR TITLE
Refactor model

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -41,6 +41,8 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
         Model::Home(m) => m,
         Model::Skill(m) => m,
         Model::Employee(m) => m,
+        Model::About(m) => m,
+        Model::NotFound(m) => m,
     };
     match &inner_model.page {
         Page::Home => page::home::init(orders.proxy(Msg::Home)),
@@ -95,6 +97,8 @@ pub fn view(model: &Model) -> impl IntoNodes<Msg> {
         Model::Home(m) => m,
         Model::Skill(m) => m,
         Model::Employee(m) => m,
+        Model::About(m) => m,
+        Model::NotFound(m) => m,
     };
     div![
         C![

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -37,7 +37,12 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
     orders.subscribe(Msg::UrlChanged);
 
     let model = Model::new(url);
-    match &model.page {
+    let inner_model = match &model {
+        Model::Home(m) => m,
+        Model::Skill(m) => m,
+        Model::Employee(m) => m,
+    };
+    match &inner_model.page {
         Page::Home => page::home::init(orders.proxy(Msg::Home)),
         Page::About => page::about::init(orders.proxy(Msg::About)),
         Page::Skill(id) => page::skill::init(orders.proxy(Msg::Skill), id),
@@ -55,21 +60,42 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             *model = init(url, orders);
         },
         Msg::Home(inner_msg) => {
-            page::home::update(&mut orders.proxy(Msg::Home), model, inner_msg)
+            if let Model::Home(inner_model) = model {
+                page::home::update(
+                    &mut orders.proxy(Msg::Home),
+                    inner_model,
+                    inner_msg,
+                );
+            }
         },
         Msg::Skill(inner_msg) => {
-            page::skill::update(&mut orders.proxy(Msg::Skill), model, inner_msg)
+            if let Model::Skill(inner_model) = model {
+                page::skill::update(
+                    &mut orders.proxy(Msg::Skill),
+                    inner_model,
+                    inner_msg,
+                );
+            }
         },
-        Msg::Employee(inner_msg) => page::employee::update(
-            &mut orders.proxy(Msg::Employee),
-            model,
-            inner_msg,
-        ),
+        Msg::Employee(inner_msg) => {
+            if let Model::Employee(inner_model) = model {
+                page::employee::update(
+                    &mut orders.proxy(Msg::Employee),
+                    inner_model,
+                    inner_msg,
+                );
+            }
+        },
         _ => unimplemented!(),
     }
 }
 
 pub fn view(model: &Model) -> impl IntoNodes<Msg> {
+    let model = match model {
+        Model::Home(m) => m,
+        Model::Skill(m) => m,
+        Model::Employee(m) => m,
+    };
     div![
         C![
             IF!(not(model.in_prerendering) => C.fade_in),

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -11,12 +11,11 @@ extern crate console_error_panic_hook;
 
 use seed::{prelude::*, *};
 
-use generated::css_classes::C;
-
 mod generated;
 mod page;
 
-use page::{Model, Page};
+use page::*;
+use generated::css_classes::C;
 
 #[macro_use]
 extern crate serde_derive;
@@ -37,32 +36,28 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
     orders.subscribe(Msg::UrlChanged);
 
     let model = Model::new(url);
-    let inner_model = match &model {
-        Model::Home(m) => m,
-        Model::Skill(m) => m,
-        Model::Employee(m) => m,
-        Model::About(m) => m,
-        Model::NotFound(m) => m,
-    };
-    match &inner_model.page {
-        Page::Home => page::home::init(orders.proxy(Msg::Home)),
-        Page::About => page::about::init(orders.proxy(Msg::About)),
-        Page::Skill(id) => page::skill::init(orders.proxy(Msg::Skill), id),
-        Page::Employee(id) => {
-            page::employee::init(orders.proxy(Msg::Employee), id)
-        },
-        Page::NotFound => page::not_found::init(orders.proxy(Msg::NotFound)),
+    match &model.page_model {
+        PageModel::Home(_) => page::home::init(orders.proxy(Msg::Home)),
+        PageModel::About(_) => page::about::init(orders.proxy(Msg::About)),
+        PageModel::Skill(inner_model) =>
+            page::skill::init(orders.proxy(Msg::Skill), &inner_model.skill_id),
+        PageModel::Employee(inner_model) =>
+            page::employee::init(orders.proxy(Msg::Employee), &inner_model.employee_id),
+        PageModel::NotFound(_) => page::not_found::init(orders.proxy(Msg::NotFound)),
     }
+    page::partial::header::init(orders.proxy(Msg::Header));
+    page::partial::footer::init(orders.proxy(Msg::Footer));
     model
 }
 
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
+    let page_model = &mut model.page_model;
     match msg {
         Msg::UrlChanged(subs::UrlChanged(url)) => {
             *model = init(url, orders);
         },
         Msg::Home(inner_msg) => {
-            if let Model::Home(inner_model) = model {
+            if let PageModel::Home(inner_model) = page_model {
                 page::home::update(
                     &mut orders.proxy(Msg::Home),
                     inner_model,
@@ -71,7 +66,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         },
         Msg::Skill(inner_msg) => {
-            if let Model::Skill(inner_model) = model {
+            if let PageModel::Skill(inner_model) = page_model {
                 page::skill::update(
                     &mut orders.proxy(Msg::Skill),
                     inner_model,
@@ -80,7 +75,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         },
         Msg::Employee(inner_msg) => {
-            if let Model::Employee(inner_model) = model {
+            if let PageModel::Employee(inner_model) = page_model {
                 page::employee::update(
                     &mut orders.proxy(Msg::Employee),
                     inner_model,
@@ -88,35 +83,43 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                 );
             }
         },
-        _ => unimplemented!(),
+        Msg::Header(inner_msg) => {
+            page::partial::header::update(
+                &mut orders.proxy(Msg::Header),
+                &mut model.header_model,
+                inner_msg,
+            );
+        },
+        Msg::Footer(inner_msg) => {
+            page::partial::footer::update(
+                &mut orders.proxy(Msg::Footer),
+                &mut model.footer_model,
+                inner_msg,
+            )
+        },
+        Msg::About(_) => unimplemented!(),
+        Msg::NotFound(_) => unimplemented!(),
     }
 }
 
 pub fn view(model: &Model) -> impl IntoNodes<Msg> {
-    let model = match model {
-        Model::Home(m) => m,
-        Model::Skill(m) => m,
-        Model::Employee(m) => m,
-        Model::About(m) => m,
-        Model::NotFound(m) => m,
-    };
     div![
         C![
-            IF!(not(model.in_prerendering) => C.fade_in),
+            IF!(not(model.is_in_prerendering()) => C.fade_in),
             C.min_h_screen,
             C.flex,
             C.flex_col,
         ],
-        match &model.page {
-            Page::Home => page::home::view(model).map_msg(Msg::Home),
-            Page::About => page::about::view().map_msg(Msg::About),
-            Page::Skill(_) => page::skill::view(model).map_msg(Msg::Skill),
-            Page::Employee(_) =>
-                page::employee::view(model).map_msg(Msg::Employee),
-            Page::NotFound => page::not_found::view().map_msg(Msg::NotFound),
+        match &model.page_model {
+            PageModel::Home(inner_model) => page::home::view(&inner_model).map_msg(Msg::Home),
+            PageModel::About(inner_model) => page::about::view(&inner_model).map_msg(Msg::About),
+            PageModel::Skill(inner_model) => page::skill::view(&inner_model).map_msg(Msg::Skill),
+            PageModel::Employee(inner_model) =>
+                page::employee::view(&inner_model).map_msg(Msg::Employee),
+            PageModel::NotFound(inner_model) => page::not_found::view(&inner_model).map_msg(Msg::NotFound),
         },
-        page::partial::header::view(model).map_msg(Msg::Header),
-        page::partial::footer::view().map_msg(Msg::Footer),
+        page::partial::header::view(&model.header_model).map_msg(Msg::Header),
+        page::partial::footer::view(&model.footer_model).map_msg(Msg::Footer),
     ]
 }
 

--- a/frontend/src/page/about.rs
+++ b/frontend/src/page/about.rs
@@ -8,7 +8,7 @@ pub fn init(mut _orders: impl Orders<Msg>) {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn view() -> Node<Msg> {
+pub fn view(_: &InnerModel) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Resume section

--- a/frontend/src/page/about.rs
+++ b/frontend/src/page/about.rs
@@ -1,5 +1,7 @@
 use crate::page::*;
 
+pub struct Model;
+
 #[derive(Debug)]
 pub enum Msg {}
 
@@ -8,7 +10,7 @@ pub fn init(mut _orders: impl Orders<Msg>) {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn view(_: &InnerModel) -> Node<Msg> {
+pub fn view(_: &Model) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Resume section

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -1,6 +1,28 @@
 use crate::page::*;
+use crate::page::partial::header::Model as HeaderModel;
+use crate::page::partial::footer::Model as FooterModel;
 
-pub enum Model {
+pub struct Model {
+    pub header_model: HeaderModel,
+    pub footer_model: FooterModel,
+    pub page_model: PageModel,
+}
+
+impl Model {
+    pub fn new(url: Url) -> Self {
+        Self {
+            header_model: HeaderModel::new(&url),
+            footer_model: FooterModel,
+            page_model: PageModel::new(url),
+        }
+    }
+
+    pub fn is_in_prerendering(&self) -> bool {
+        self.header_model.in_prerendering
+    }
+}
+
+pub enum PageModel {
     Home(InnerModel),
     Skill(InnerModel),
     Employee(InnerModel),
@@ -8,51 +30,54 @@ pub enum Model {
     NotFound(InnerModel),
 }
 
-impl Model {
-    pub fn new(url: Url) -> Model {
-        let inner_model = InnerModel::new(url);
-        match &inner_model.page {
-            Page::Home => Model::Home(inner_model),
-            Page::Skill(_) => Model::Skill(inner_model),
-            Page::Employee(_) => Model::Employee(inner_model),
-            Page::About => Model::About(inner_model),
-            Page::NotFound => Model::NotFound(inner_model),
+impl PageModel {
+    pub fn new(url: Url) -> Self {
+        let mut inner_model = InnerModel::new(&url);
+        let page = Page::new(url);
+        match page {
+            Page::Home => Self::Home(inner_model),
+            Page::Skill(id) => {
+                inner_model.skill_id = id;
+                Self::Skill(inner_model)
+            },
+            Page::Employee(id) => {
+                inner_model.employee_id = id;
+                Self::Employee(inner_model)
+            },
+            Page::About => Self::About(inner_model),
+            Page::NotFound => Self::NotFound(inner_model),
         }
     }
 }
 
 pub struct InnerModel {
     pub base_url: Url,
-    pub page: Page,
-    pub scroll_history: ScrollHistory,
-    pub menu_visibility: Visibility,
-    pub in_prerendering: bool,
     // home
     pub search_query: String,
     pub matched_skills: Vec<Skill>,
     // skill page
+    pub skill_id: String,
     pub skill: Option<Skill>,
     pub matched_employees: Vec<Employee>,
     pub error: Option<String>,
     // employee page
+    pub employee_id: String,
     pub employee: Option<Employee>,
     pub employee_skills: Vec<Skill>,
     pub error_employee: Option<String>,
 }
 
 impl InnerModel {
-    pub fn new(url: Url) -> Self {
+    pub fn new(url: &Url) -> Self {
         InnerModel {
             base_url: url.to_base_url(),
-            page: Page::new(url),
-            scroll_history: ScrollHistory::new(),
-            menu_visibility: Visibility::Hidden,
-            in_prerendering: is_in_prerendering(),
             search_query: String::new(),
             matched_skills: Vec::new(),
+            skill_id: String::new(),
             skill: None,
             matched_employees: Vec::new(),
             error: None,
+            employee_id: String::new(),
             employee: None,
             employee_skills: Vec::new(),
             error_employee: None,

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -22,7 +22,7 @@ impl Model {
 
 pub enum PageModel {
     Home(home::Model),
-    Skill(InnerModel),
+    Skill(skill::Model),
     Employee(InnerModel),
     About(about::Model),
     NotFound(not_found::Model),
@@ -34,10 +34,7 @@ impl PageModel {
         let page = Page::new(url.clone());
         match page {
             Page::Home => Self::Home(home::Model::new(&url)),
-            Page::Skill(id) => {
-                inner_model.skill_id = id;
-                Self::Skill(inner_model)
-            },
+            Page::Skill(id) => Self::Skill(skill::Model::new(&url, id)),
             Page::Employee(id) => {
                 inner_model.employee_id = id;
                 Self::Employee(inner_model)

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -4,6 +4,8 @@ pub enum Model {
     Home(InnerModel),
     Skill(InnerModel),
     Employee(InnerModel),
+    About(InnerModel),
+    NotFound(InnerModel),
 }
 
 impl Model {
@@ -13,7 +15,8 @@ impl Model {
             Page::Home => Model::Home(inner_model),
             Page::Skill(_) => Model::Skill(inner_model),
             Page::Employee(_) => Model::Employee(inner_model),
-            _ => unimplemented!(),
+            Page::About => Model::About(inner_model),
+            Page::NotFound => Model::NotFound(inner_model),
         }
     }
 }

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -1,7 +1,24 @@
 use crate::page::*;
 
-// TODO: separate into a model for each page
-pub struct Model {
+pub enum Model {
+    Home(InnerModel),
+    Skill(InnerModel),
+    Employee(InnerModel),
+}
+
+impl Model {
+    pub fn new(url: Url) -> Model {
+        let inner_model = InnerModel::new(url);
+        match &inner_model.page {
+            Page::Home => Model::Home(inner_model),
+            Page::Skill(_) => Model::Skill(inner_model),
+            Page::Employee(_) => Model::Employee(inner_model),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct InnerModel {
     pub base_url: Url,
     pub page: Page,
     pub scroll_history: ScrollHistory,
@@ -20,9 +37,9 @@ pub struct Model {
     pub error_employee: Option<String>,
 }
 
-impl Model {
+impl InnerModel {
     pub fn new(url: Url) -> Self {
-        Model {
+        InnerModel {
             base_url: url.to_base_url(),
             page: Page::new(url),
             scroll_history: ScrollHistory::new(),

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -1,18 +1,16 @@
 use crate::page::*;
-use crate::page::partial::header::Model as HeaderModel;
-use crate::page::partial::footer::Model as FooterModel;
 
 pub struct Model {
-    pub header_model: HeaderModel,
-    pub footer_model: FooterModel,
+    pub header_model: partial::header::Model,
+    pub footer_model: partial::footer::Model,
     pub page_model: PageModel,
 }
 
 impl Model {
     pub fn new(url: Url) -> Self {
         Self {
-            header_model: HeaderModel::new(&url),
-            footer_model: FooterModel,
+            header_model: partial::header::Model::new(&url),
+            footer_model: partial::footer::Model,
             page_model: PageModel::new(url),
         }
     }
@@ -26,7 +24,7 @@ pub enum PageModel {
     Home(InnerModel),
     Skill(InnerModel),
     Employee(InnerModel),
-    About(InnerModel),
+    About(about::Model),
     NotFound(InnerModel),
 }
 
@@ -44,7 +42,7 @@ impl PageModel {
                 inner_model.employee_id = id;
                 Self::Employee(inner_model)
             },
-            Page::About => Self::About(inner_model),
+            Page::About => Self::About(about::Model),
             Page::NotFound => Self::NotFound(inner_model),
         }
     }

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -23,54 +23,20 @@ impl Model {
 pub enum PageModel {
     Home(home::Model),
     Skill(skill::Model),
-    Employee(InnerModel),
+    Employee(employee::Model),
     About(about::Model),
     NotFound(not_found::Model),
 }
 
 impl PageModel {
     pub fn new(url: Url) -> Self {
-        let mut inner_model = InnerModel::new(&url);
         let page = Page::new(url.clone());
         match page {
             Page::Home => Self::Home(home::Model::new(&url)),
             Page::Skill(id) => Self::Skill(skill::Model::new(&url, id)),
-            Page::Employee(id) => {
-                inner_model.employee_id = id;
-                Self::Employee(inner_model)
-            },
+            Page::Employee(id) => Self::Employee(employee::Model::new(&url, id)),
             Page::About => Self::About(about::Model),
             Page::NotFound => Self::NotFound(not_found::Model),
-        }
-    }
-}
-
-pub struct InnerModel {
-    pub base_url: Url,
-    // skill page
-    pub skill_id: String,
-    pub skill: Option<Skill>,
-    pub matched_employees: Vec<Employee>,
-    pub error: Option<String>,
-    // employee page
-    pub employee_id: String,
-    pub employee: Option<Employee>,
-    pub employee_skills: Vec<Skill>,
-    pub error_employee: Option<String>,
-}
-
-impl InnerModel {
-    pub fn new(url: &Url) -> Self {
-        Self {
-            base_url: url.to_base_url(),
-            skill_id: String::new(),
-            skill: None,
-            matched_employees: Vec::new(),
-            error: None,
-            employee_id: String::new(),
-            employee: None,
-            employee_skills: Vec::new(),
-            error_employee: None,
         }
     }
 }

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -30,11 +30,12 @@ pub enum PageModel {
 
 impl PageModel {
     pub fn new(url: Url) -> Self {
+        let base_url = url.to_base_url();
         let page = Page::new(url.clone());
         match page {
-            Page::Home => Self::Home(home::Model::new(&url)),
-            Page::Skill(id) => Self::Skill(skill::Model::new(&url, id)),
-            Page::Employee(id) => Self::Employee(employee::Model::new(&url, id)),
+            Page::Home => Self::Home(home::Model::new(base_url)),
+            Page::Skill(id) => Self::Skill(skill::Model::new(base_url, id)),
+            Page::Employee(id) => Self::Employee(employee::Model::new(base_url, id)),
             Page::About => Self::About(about::Model),
             Page::NotFound => Self::NotFound(not_found::Model),
         }

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -21,7 +21,7 @@ impl Model {
 }
 
 pub enum PageModel {
-    Home(InnerModel),
+    Home(home::Model),
     Skill(InnerModel),
     Employee(InnerModel),
     About(about::Model),
@@ -31,9 +31,9 @@ pub enum PageModel {
 impl PageModel {
     pub fn new(url: Url) -> Self {
         let mut inner_model = InnerModel::new(&url);
-        let page = Page::new(url);
+        let page = Page::new(url.clone());
         match page {
-            Page::Home => Self::Home(inner_model),
+            Page::Home => Self::Home(home::Model::new(&url)),
             Page::Skill(id) => {
                 inner_model.skill_id = id;
                 Self::Skill(inner_model)
@@ -50,9 +50,6 @@ impl PageModel {
 
 pub struct InnerModel {
     pub base_url: Url,
-    // home
-    pub search_query: String,
-    pub matched_skills: Vec<Skill>,
     // skill page
     pub skill_id: String,
     pub skill: Option<Skill>,
@@ -67,10 +64,8 @@ pub struct InnerModel {
 
 impl InnerModel {
     pub fn new(url: &Url) -> Self {
-        InnerModel {
+        Self {
             base_url: url.to_base_url(),
-            search_query: String::new(),
-            matched_skills: Vec::new(),
             skill_id: String::new(),
             skill: None,
             matched_employees: Vec::new(),

--- a/frontend/src/page/common/model.rs
+++ b/frontend/src/page/common/model.rs
@@ -25,7 +25,7 @@ pub enum PageModel {
     Skill(InnerModel),
     Employee(InnerModel),
     About(about::Model),
-    NotFound(InnerModel),
+    NotFound(not_found::Model),
 }
 
 impl PageModel {
@@ -43,7 +43,7 @@ impl PageModel {
                 Self::Employee(inner_model)
             },
             Page::About => Self::About(about::Model),
-            Page::NotFound => Self::NotFound(inner_model),
+            Page::NotFound => Self::NotFound(not_found::Model),
         }
     }
 }

--- a/frontend/src/page/employee.rs
+++ b/frontend/src/page/employee.rs
@@ -64,7 +64,11 @@ fn request_skills(orders: &mut impl Orders<Msg>, id: &str) {
     });
 }
 
-pub fn update(_orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
+pub fn update(
+    _orders: &mut impl Orders<Msg>,
+    model: &mut InnerModel,
+    msg: Msg,
+) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     match msg {
         Msg::EmployeeLoaded(employee) => {
@@ -79,7 +83,7 @@ pub fn update(_orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
     }
 }
 
-fn list_skills(model: &Model) -> Vec<Node<Msg>> {
+fn list_skills(model: &InnerModel) -> Vec<Node<Msg>> {
     model
         .employee_skills
         .clone()
@@ -107,7 +111,7 @@ fn list_skills(model: &Model) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn view(model: &Model) -> Node<Msg> {
+pub fn view(model: &InnerModel) -> Node<Msg> {
     match &model.error {
         None => employee_found_view(model),
         Some(_) => employee_not_found_view(model),
@@ -115,7 +119,7 @@ pub fn view(model: &Model) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn employee_not_found_view(model: &Model) -> Node<Msg> {
+pub fn employee_not_found_view(model: &InnerModel) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Main section
@@ -185,7 +189,7 @@ pub fn employee_not_found_view(model: &Model) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn employee_found_view(model: &Model) -> Node<Msg> {
+pub fn employee_found_view(model: &InnerModel) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Main section

--- a/frontend/src/page/employee.rs
+++ b/frontend/src/page/employee.rs
@@ -1,5 +1,25 @@
 use crate::page::*;
 
+pub struct Model {
+    pub base_url: Url,
+    pub employee_id: String,
+    pub employee: Option<Employee>,
+    pub employee_skills: Vec<Skill>,
+    pub error: Option<String>,
+}
+
+impl Model {
+    pub fn new(url: &Url, employee_id: String) -> Self {
+        Self {
+            base_url: url.to_base_url(),
+            employee_id,
+            employee: None,
+            employee_skills: Vec::new(),
+            error: None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Msg {
     EmployeeLoaded(Employee),
@@ -66,7 +86,7 @@ fn request_skills(orders: &mut impl Orders<Msg>, id: &str) {
 
 pub fn update(
     _orders: &mut impl Orders<Msg>,
-    model: &mut InnerModel,
+    model: &mut Model,
     msg: Msg,
 ) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
@@ -78,12 +98,12 @@ pub fn update(
             model.employee_skills = skills;
         },
         Msg::RequestNOK(err_msg) => {
-            model.error_employee = Some(err_msg);
+            model.error = Some(err_msg);
         },
     }
 }
 
-fn list_skills(model: &InnerModel) -> Vec<Node<Msg>> {
+fn list_skills(model: &Model) -> Vec<Node<Msg>> {
     model
         .employee_skills
         .clone()
@@ -111,7 +131,7 @@ fn list_skills(model: &InnerModel) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn view(model: &InnerModel) -> Node<Msg> {
+pub fn view(model: &Model) -> Node<Msg> {
     match &model.error {
         None => employee_found_view(model),
         Some(_) => employee_not_found_view(model),
@@ -119,7 +139,7 @@ pub fn view(model: &InnerModel) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn employee_not_found_view(model: &InnerModel) -> Node<Msg> {
+pub fn employee_not_found_view(model: &Model) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Main section
@@ -165,7 +185,7 @@ pub fn employee_not_found_view(model: &InnerModel) -> Node<Msg> {
                                 C.lg__leading_none,
                                 C.lg__text_120,
                             ],
-                            span!["Skill not found in the "],
+                            span!["Employee not found in the "],
                             span![C![C.font_bold], "Database"],
                         ]
                     ],
@@ -189,7 +209,7 @@ pub fn employee_not_found_view(model: &InnerModel) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn employee_found_view(model: &InnerModel) -> Node<Msg> {
+pub fn employee_found_view(model: &Model) -> Node<Msg> {
     div![
         C![C.flex_grow,],
         // Main section

--- a/frontend/src/page/employee.rs
+++ b/frontend/src/page/employee.rs
@@ -9,9 +9,9 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(url: &Url, employee_id: String) -> Self {
+    pub fn new(base_url: Url, employee_id: String) -> Self {
         Self {
-            base_url: url.to_base_url(),
+            base_url,
             employee_id,
             employee: None,
             employee_skills: Vec::new(),

--- a/frontend/src/page/home.rs
+++ b/frontend/src/page/home.rs
@@ -2,17 +2,12 @@ use crate::page::*;
 
 #[derive(Debug)]
 pub enum Msg {
-    ScrollToTop,
-    Scrolled,
-    ToggleMenu,
     SearchQueryChanged(String),
-    HideMenu,
     Received(Vec<Skill>),
 }
 
-pub fn init(mut orders: impl Orders<Msg>) {
+pub fn init(mut _orders: impl Orders<Msg>) {
     document().set_title(TITLE_SUFFIX);
-    orders.stream(streams::window_event(Ev::Scroll, |_| Msg::Scrolled));
 }
 
 pub fn generate_skill_list(model: &InnerModel) -> Vec<Node<Msg>> {
@@ -47,23 +42,6 @@ pub fn generate_skill_list(model: &InnerModel) -> Vec<Node<Msg>> {
 pub fn update(orders: &mut impl Orders<Msg>, model: &mut InnerModel, msg: Msg) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     match msg {
-        Msg::ScrollToTop => window().scroll_to_with_scroll_to_options(
-            web_sys::ScrollToOptions::new().top(0.),
-        ),
-        Msg::Scrolled => {
-            let mut position = body().scroll_top();
-            if position == 0 {
-                position = document()
-                    .document_element()
-                    .expect("get document element")
-                    .scroll_top()
-            }
-            *model.scroll_history.push_back() = position;
-        },
-        Msg::ToggleMenu => model.menu_visibility.toggle(),
-        Msg::HideMenu => {
-            model.menu_visibility = Visibility::Hidden;
-        },
         Msg::SearchQueryChanged(query) => {
             model.search_query = query.clone();
 

--- a/frontend/src/page/home.rs
+++ b/frontend/src/page/home.rs
@@ -1,5 +1,21 @@
 use crate::page::*;
 
+pub struct Model {
+    pub base_url: Url,
+    pub search_query: String,
+    pub matched_skills: Vec<Skill>,
+}
+
+impl Model {
+    pub fn new(url: &Url) -> Self {
+        Self {
+            base_url: url.to_base_url(),
+            search_query: String::new(),
+            matched_skills: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Msg {
     SearchQueryChanged(String),
@@ -10,7 +26,7 @@ pub fn init(mut _orders: impl Orders<Msg>) {
     document().set_title(TITLE_SUFFIX);
 }
 
-pub fn generate_skill_list(model: &InnerModel) -> Vec<Node<Msg>> {
+pub fn generate_skill_list(model: &Model) -> Vec<Node<Msg>> {
     seed::log("matched skills:");
     seed::log(model.matched_skills.clone());
 
@@ -39,7 +55,7 @@ pub fn generate_skill_list(model: &InnerModel) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn update(orders: &mut impl Orders<Msg>, model: &mut InnerModel, msg: Msg) {
+pub fn update(orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     match msg {
         Msg::SearchQueryChanged(query) => {
@@ -80,7 +96,7 @@ pub fn update(orders: &mut impl Orders<Msg>, model: &mut InnerModel, msg: Msg) {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn view(model: &InnerModel) -> Node<Msg> {
+pub fn view(model: &Model) -> Node<Msg> {
     if !model.matched_skills.is_empty() {
         seed::log(&model.matched_skills[0].skill);
     }

--- a/frontend/src/page/home.rs
+++ b/frontend/src/page/home.rs
@@ -7,9 +7,9 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(url: &Url) -> Self {
+    pub fn new(base_url: Url) -> Self {
         Self {
-            base_url: url.to_base_url(),
+            base_url,
             search_query: String::new(),
             matched_skills: Vec::new(),
         }

--- a/frontend/src/page/home.rs
+++ b/frontend/src/page/home.rs
@@ -15,7 +15,7 @@ pub fn init(mut orders: impl Orders<Msg>) {
     orders.stream(streams::window_event(Ev::Scroll, |_| Msg::Scrolled));
 }
 
-pub fn generate_skill_list(model: &Model) -> Vec<Node<Msg>> {
+pub fn generate_skill_list(model: &InnerModel) -> Vec<Node<Msg>> {
     seed::log("matched skills:");
     seed::log(model.matched_skills.clone());
 
@@ -44,7 +44,7 @@ pub fn generate_skill_list(model: &Model) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn update(orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
+pub fn update(orders: &mut impl Orders<Msg>, model: &mut InnerModel, msg: Msg) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     match msg {
         Msg::ScrollToTop => window().scroll_to_with_scroll_to_options(
@@ -102,7 +102,7 @@ pub fn update(orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn view(model: &Model) -> Node<Msg> {
+pub fn view(model: &InnerModel) -> Node<Msg> {
     if !model.matched_skills.is_empty() {
         seed::log(&model.matched_skills[0].skill);
     }

--- a/frontend/src/page/not_found.rs
+++ b/frontend/src/page/not_found.rs
@@ -7,7 +7,7 @@ pub fn init(mut _orders: impl Orders<Msg>) {
     document().set_title(&format!("404 - {}", TITLE_SUFFIX));
 }
 
-pub fn view() -> Node<Msg> {
+pub fn view(_: &InnerModel) -> Node<Msg> {
     div![
         C![
             C.mt_16,

--- a/frontend/src/page/not_found.rs
+++ b/frontend/src/page/not_found.rs
@@ -1,5 +1,7 @@
 use crate::page::*;
 
+pub struct Model;
+
 #[derive(Debug)]
 pub enum Msg {}
 
@@ -7,7 +9,7 @@ pub fn init(mut _orders: impl Orders<Msg>) {
     document().set_title(&format!("404 - {}", TITLE_SUFFIX));
 }
 
-pub fn view(_: &InnerModel) -> Node<Msg> {
+pub fn view(_: &Model) -> Node<Msg> {
     div![
         C![
             C.mt_16,

--- a/frontend/src/page/partial/footer.rs
+++ b/frontend/src/page/partial/footer.rs
@@ -1,9 +1,15 @@
 use crate::page::*;
 
+pub struct Model;
+
 #[derive(Debug)]
 pub enum Msg {}
 
-pub fn view() -> Node<Msg> {
+pub fn init(mut _orders: impl Orders<Msg>) {}
+
+pub fn update(_orders: &mut impl Orders<Msg>, _model: &mut Model, _msg: Msg) {}
+
+pub fn view(_: &Model) -> Node<Msg> {
     footer![
         C![
             C.h_16,

--- a/frontend/src/page/partial/header.rs
+++ b/frontend/src/page/partial/header.rs
@@ -23,7 +23,7 @@ fn header_visibility(
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn view(model: &Model) -> Vec<Node<Msg>> {
+pub fn view(model: &InnerModel) -> Vec<Node<Msg>> {
     let show_header =
         header_visibility(model.menu_visibility, &model.scroll_history)
             == Visibility::Visible;

--- a/frontend/src/page/skill.rs
+++ b/frontend/src/page/skill.rs
@@ -9,9 +9,9 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(url: &Url, skill_id: String) -> Self {
+    pub fn new(base_url: Url, skill_id: String) -> Self {
         Self {
-            base_url: url.to_base_url(),
+            base_url,
             skill_id,
             skill: None,
             matched_employees: Vec::new(),

--- a/frontend/src/page/skill.rs
+++ b/frontend/src/page/skill.rs
@@ -1,5 +1,25 @@
 use crate::page::*;
 
+pub struct Model {
+    pub base_url: Url,
+    pub skill_id: String,
+    pub skill: Option<Skill>,
+    pub matched_employees: Vec<Employee>,
+    pub error: Option<String>,
+}
+
+impl Model {
+    pub fn new(url: &Url, skill_id: String) -> Self {
+        Self {
+            base_url: url.to_base_url(),
+            skill_id,
+            skill: None,
+            matched_employees: Vec::new(),
+            error: None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Msg {
     SkillLoaded(Skill),
@@ -66,7 +86,7 @@ fn request_employees(orders: &mut impl Orders<Msg>, id: &str) {
 
 pub fn update(
     _orders: &mut impl Orders<Msg>,
-    model: &mut InnerModel,
+    model: &mut Model,
     msg: Msg,
 ) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
@@ -83,7 +103,7 @@ pub fn update(
     }
 }
 
-fn list_employees(model: &InnerModel) -> Vec<Node<Msg>> {
+fn list_employees(model: &Model) -> Vec<Node<Msg>> {
     model
         .matched_employees
         .clone()
@@ -102,7 +122,7 @@ fn list_employees(model: &InnerModel) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn view(model: &InnerModel) -> Node<Msg> {
+pub fn view(model: &Model) -> Node<Msg> {
     match &model.error {
         None => skill_found_view(model),
         Some(_) => skill_not_found_view(model),
@@ -110,7 +130,7 @@ pub fn view(model: &InnerModel) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn skill_not_found_view(model: &InnerModel) -> Node<Msg> {
+pub fn skill_not_found_view(model: &Model) -> Node<Msg> {
     if !model.matched_employees.is_empty() {
         seed::log(&model.matched_employees[0].name);
     }
@@ -184,7 +204,7 @@ pub fn skill_not_found_view(model: &InnerModel) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn skill_found_view(model: &InnerModel) -> Node<Msg> {
+pub fn skill_found_view(model: &Model) -> Node<Msg> {
     if !model.matched_employees.is_empty() {
         seed::log(&model.matched_employees[0].name);
     }

--- a/frontend/src/page/skill.rs
+++ b/frontend/src/page/skill.rs
@@ -64,7 +64,11 @@ fn request_employees(orders: &mut impl Orders<Msg>, id: &str) {
     });
 }
 
-pub fn update(_orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
+pub fn update(
+    _orders: &mut impl Orders<Msg>,
+    model: &mut InnerModel,
+    msg: Msg,
+) {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     match msg {
         Msg::SkillLoaded(skill) => {
@@ -79,7 +83,7 @@ pub fn update(_orders: &mut impl Orders<Msg>, model: &mut Model, msg: Msg) {
     }
 }
 
-fn list_employees(model: &Model) -> Vec<Node<Msg>> {
+fn list_employees(model: &InnerModel) -> Vec<Node<Msg>> {
     model
         .matched_employees
         .clone()
@@ -98,7 +102,7 @@ fn list_employees(model: &Model) -> Vec<Node<Msg>> {
         .collect()
 }
 
-pub fn view(model: &Model) -> Node<Msg> {
+pub fn view(model: &InnerModel) -> Node<Msg> {
     match &model.error {
         None => skill_found_view(model),
         Some(_) => skill_not_found_view(model),
@@ -106,7 +110,7 @@ pub fn view(model: &Model) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn skill_not_found_view(model: &Model) -> Node<Msg> {
+pub fn skill_not_found_view(model: &InnerModel) -> Node<Msg> {
     if !model.matched_employees.is_empty() {
         seed::log(&model.matched_employees[0].name);
     }
@@ -180,7 +184,7 @@ pub fn skill_not_found_view(model: &Model) -> Node<Msg> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn skill_found_view(model: &Model) -> Node<Msg> {
+pub fn skill_found_view(model: &InnerModel) -> Node<Msg> {
     if !model.matched_employees.is_empty() {
         seed::log(&model.matched_employees[0].name);
     }


### PR DESCRIPTION
- divided monolithic model into a model for each page (model now contains header model, footer model and the actual page model, which depends on the url)
- model does not remember page type anymore (unnecessary since model type already tells us the page)
- moved scrolling behaviour from model to header, so that it works on every page
- commented out some stuff in header view which deals with the about page. I don't know what it is
- fixed a bug with "employee not found"

closes #12 